### PR TITLE
Add window-resize example

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "i18next-browser-languagedetector": "3.0.3",
     "i18next-xhr-backend": "3.1.1",
     "intl": "^1.2.5",
+    "mq-polyfill": "^1.1.8",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-i18next": "^10.11.2",

--- a/src/__tests__/window-resize.js
+++ b/src/__tests__/window-resize.js
@@ -1,0 +1,51 @@
+import {render} from '@testing-library/react'
+import matchMediaPolyfill from 'mq-polyfill'
+import React from 'react'
+
+function WindowSize () {
+  return (
+    <div>
+      <label htmlFor='inner-width'>Inner Width</label>
+      <div id='inner-width'>{window.innerWidth}</div>
+      <label htmlFor='inner-height'>Inner Height</label>
+      <div id='inner-height'>{window.innerHeight}</div>
+      <label htmlFor='outer-width'>Outer Width</label>
+      <div id='outer-width'>{window.outerWidth}</div>
+      <label htmlFor='outer-height'>Outer Height</label>
+      <div id='outer-height'>{window.outerHeight}</div>
+    </div>
+  )
+}
+
+beforeAll(() => {
+  matchMediaPolyfill(window)
+  window.resizeTo = function resizeTo(width, height) {
+    Object.assign(this, {
+      innerWidth: width,
+      innerHeight: height,
+      outerWidth: width,
+      outerHeight: height,
+    }).dispatchEvent(new this.Event('resize'))
+  }
+  console.log('test')
+})
+
+test('shows default window size correctly', () => {
+  const {getByLabelText} = render(<WindowSize />)
+
+  expect(getByLabelText('Inner Width')).toHaveTextContent(1024)
+  expect(getByLabelText('Inner Height')).toHaveTextContent(768)
+  expect(getByLabelText('Outer Width')).toHaveTextContent(1024)
+  expect(getByLabelText('Outer Height')).toHaveTextContent(768)
+})
+
+test('shows modified window size correctly', () => {
+  window.resizeTo(800, 300)
+
+  const {getByLabelText} = render(<WindowSize />)
+
+  expect(getByLabelText('Inner Width')).toHaveTextContent(800)
+  expect(getByLabelText('Inner Height')).toHaveTextContent(300)
+  expect(getByLabelText('Outer Width')).toHaveTextContent(800)
+  expect(getByLabelText('Outer Height')).toHaveTextContent(300)
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -6430,6 +6430,11 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
+mq-polyfill@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/mq-polyfill/-/mq-polyfill-1.1.8.tgz#c144190b21214bf8d8b099e7e34e6ca2b888dc14"
+  integrity sha1-wUQZCyEhS/jYsJnn405soriI3BQ=
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
Add an example for testing modified window size which is rendered by `jsdom`.

Based on @kentcdodds's [comment](https://github.com/testing-library/react-testing-library/issues/353#issuecomment-510074776).