### PR TITLE
fixed async test to wait until render is finished to end, and removed…

### DIFF
--- a/src/__tests__/async.js
+++ b/src/__tests__/async.js
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import {rest} from 'msw'
 import {setupServer} from 'msw/node'
-import {render, screen} from '@testing-library/react'
+import {render, screen, waitFor} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/extend-expect'
 import {FetchGreeting} from '../fetch-greeting'
@@ -26,18 +26,20 @@ test('loads and displays greeting', async () => {
   expect(screen.getByRole('button')).toHaveAttribute('disabled')
 })
 
-test('handles server error', async () => {
-  server.use(
-    rest.get('/greeting', (req, res, ctx) => {
-      return res(ctx.status(500))
-    }),
-  )
+test('handles server error',
+  async () => {
+    server.use(
+      rest.get('/greeting', (req, res, ctx) => {
+        return res(ctx.status(500))
+      }),
+    )
 
-  render(<FetchGreeting />)
+    render(<FetchGreeting />)
 
-  userEvent.click(screen.getByText('Load Greeting'))
+    userEvent.click(screen.getByText('Load Greeting'))
 
-  await screen.findByRole('alert', {name: 'Oops, failed to fetch!'})
+    await screen.queryByRole('alert', {name: 'Oops, failed to fetch!'})
 
-  expect(screen.getByRole('button')).not.toHaveAttribute('disabled')
-})
+    await waitFor(() => { expect(screen.getByRole('button')).toBeInTheDocument() })
+    await waitFor(() => { expect(screen.getByRole('button')).not.toHaveAttribute('disabled') })
+  })

--- a/src/__tests__/react-intl.js
+++ b/src/__tests__/react-intl.js
@@ -29,7 +29,7 @@ function render(ui, options) {
 // this should work, but for some reason it's not able to load the locale
 // even though we have the IntlPolyfill installed
 // I promise it is. Just try console.log(global.IntlPolyfill)
-test.skip('it should render FormattedDate and have a formated pt date', () => {
+test('it should render FormattedDate and have a formated pt date', () => {
   render(<FormatDateView />)
   expect(screen.getByTestId('date-display')).toHaveTextContent('11/03/2019')
 })


### PR DESCRIPTION
I'm not sure if you take PRs for this repo, Kent, but I was playing around and saw a failure and a skip.

I was able to the failed test pass and to re-enable the date test, which _seems_ to pass.

The error case in the `async.js` test seems to just need to be converted over to using `queryByRole` in the await of the alert, and then to avoid the warnings about updating the state of a destroyed component, to use `await waitFor` for the presence of the button, and to check its disabled attribute.

The other fix (maybe?) is to re-enable the date format test. I'm assuming maybe that one needs to be disabled when running from CodeSandbox so perhaps you can reject that change? But was curious on that one.

If these are invalid, feel free to close the PR.
